### PR TITLE
adding document creation from string

### DIFF
--- a/src/DocumentFactory.php
+++ b/src/DocumentFactory.php
@@ -4,6 +4,10 @@ namespace TheCodingMachine\Gotenberg;
 
 use GuzzleHttp\Psr7\LazyOpenStream;
 use Psr\Http\Message\StreamInterface;
+use Safe\Exceptions\FilesystemException;
+use function GuzzleHttp\Psr7\stream_for;
+use function Safe\fopen;
+use function Safe\fwrite;
 
 final class DocumentFactory
 {
@@ -25,5 +29,19 @@ final class DocumentFactory
     public static function makeFromStream(string $fileName, StreamInterface $fileStream): Document
     {
         return new Document($fileName, $fileStream);
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $string
+     * @return Document
+     * @throws FilesystemException
+     */
+    public static function makeFromString(string $fileName, string $string): Document
+    {
+        $fileStream = fopen('php://memory', 'rb+');
+        fwrite($fileStream, $string);
+
+        return new Document($fileName, stream_for($fileStream));
     }
 }

--- a/tests/DocumentFactoryTest.php
+++ b/tests/DocumentFactoryTest.php
@@ -15,5 +15,8 @@ class DocumentFactoryTest extends TestCase
         // case 2: uses a stream.
         $document = DocumentFactory::makeFromStream('file.pdf', new LazyOpenStream(__DIR__ . '/assets/file.pdf', 'r'));
         $this->assertNotEmpty($document->getFileStream());
+        // case 3: uses a string
+        $document = DocumentFactory::makeFromString('index.html', '<html>foo</html>');
+        $this->assertNotEmpty($document->getFileStream());
     }
 }


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR implements the following
* [ ] Ability to create a `Document` from a string

See https://github.com/thecodingmachine/gotenberg-php-client/issues/5 for motivation

**Test plan (required)**

Tests implemented

**Closing issues**
Fixes #5