### PR TITLE
upgrade phpstan to 0.12 and thecodingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
     "php-http/discovery": "^1.0",
     "guzzlehttp/psr7": "^1.4.2",
     "php-http/message": "^1.0",
-    "thecodingmachine/safe": "^0.1.8"
+    "thecodingmachine/safe": "^1.0"
   },
   "require-dev" : {
     "phpunit/phpunit": "^7",
     "squizlabs/php_codesniffer": "^3.2",
-    "phpstan/phpstan": "^0.10.5",
-    "thecodingmachine/phpstan-safe-rule": "^0.1.0",
-    "thecodingmachine/phpstan-strict-rules": "^0.10.7",
+    "phpstan/phpstan": "^0.12.7",
+    "thecodingmachine/phpstan-safe-rule": "^1.0",
+    "thecodingmachine/phpstan-strict-rules": "^0.12.0",
     "php-http/mock-client": "^1.0",
     "php-http/guzzle6-adapter": "^1.1",
     "doctrine/coding-standard": "^6.0"
@@ -54,7 +54,7 @@
   "scripts": {
     "csfix": "phpcbf",
     "cscheck": "phpcs",
-    "phpstan": "phpstan analyse src -c phpstan.neon --level=7 --no-progress -vvv",
+    "phpstan": "phpstan analyse src -c phpstan.neon --level=8 --no-progress -vvv",
     "phpunit": "phpunit --configuration phpunit.xml.dist"
   },
   "extra": {


### PR DESCRIPTION
**Summary**
Upgrade thecodingmachine/safe and phpstan+deps to the latest releases.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
This allows using `thecodingmachine/gotenberg-php-client:^6.1` in projects that also want use `thecodingmachine/safe:^1.0` and `phpstan/phpstan:^0.12`+ `thecodingmachine/phpstan-safe-rule^1.0`.
Without this change, projects are stuck on `phpstan/phpstan:^0.11`

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

increased phpstan level in accordance with upgrade notes. `make lint` still passes.

<!-- Make sure tests pass on both Travis and AppVeyor. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] Have you lint your code locally prior to submission (`make lint`)?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally (`make tests`)?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code