### PR TITLE
Added "scale" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ try {
     $request->setAssets($assets);
     $request->setPaperSize(Request::A4);
     $request->setMargins(Request::NO_MARGINS);
+    $request->setScale(0.75);
     
     # store method allows you to... store the resulting PDF in a particular destination.
     $client->store($request, 'path/you/want/the/pdf/to/be/stored.pdf');

--- a/src/ChromeRequest.php
+++ b/src/ChromeRequest.php
@@ -18,6 +18,7 @@ abstract class ChromeRequest extends Request implements GotenbergRequestInterfac
     private const LANDSCAPE = 'landscape';
     private const PAGE_RANGES = 'pageRanges';
     private const GOOGLE_CHROME_RPCC_BUFFER_SIZE = 'googleChromeRpccBufferSize';
+    private const SCALE = 'scale';
 
     /** @var float|null */
     private $waitDelay;
@@ -55,6 +56,9 @@ abstract class ChromeRequest extends Request implements GotenbergRequestInterfac
     /** @var int|null */
     private $googleChromeRpccBufferSize;
 
+    /** @var float|null */
+    private $scale;
+
     /**
      * @return array<string,mixed>
      */
@@ -87,6 +91,9 @@ abstract class ChromeRequest extends Request implements GotenbergRequestInterfac
         }
         if ($this->googleChromeRpccBufferSize !== null) {
             $values[self::GOOGLE_CHROME_RPCC_BUFFER_SIZE] = $this->googleChromeRpccBufferSize;
+        }
+        if ($this->scale !== null) {
+            $values[self::SCALE] = $this->scale;
         }
         $values[self::LANDSCAPE] = $this->landscape;
 
@@ -197,5 +204,10 @@ abstract class ChromeRequest extends Request implements GotenbergRequestInterfac
     public function setGoogleChromeRpccBufferSize(?int $googleChromeRpccBufferSize): void
     {
         $this->googleChromeRpccBufferSize = $googleChromeRpccBufferSize;
+    }
+
+    public function setScale(?float $scale): void
+    {
+        $this->scale = $scale;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -62,6 +62,7 @@ final class ClientTest extends TestCase
         $request->setPaperSize(Request::A4);
         $request->setMargins(Request::NO_MARGINS);
         $request->setGoogleChromeRpccBufferSize(1048576);
+        $request->setScale(0.9);
 
         return $request;
     }


### PR DESCRIPTION
**Summary**

This PR fixes/implements the following **feature**:

* [X] Support for the "Scale" PDF print option ([related](https://github.com/thecodingmachine/gotenberg/pull/168))

**Test plan (required)**

```
$ make lint test
docker-compose run --rm -T php composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
PHP CodeSniffer Config installed_paths set to ../../slevomat/coding-standard,../../doctrine/coding-standard/lib
docker-compose run --rm -T php composer run csfix
> phpcbf
............... 15 / 15 (100%)



No fixable errors were found

Time: 2.47 secs; Memory: 16MB

docker-compose run --rm -T php composer run cscheck
> phpcs
............... 15 / 15 (100%)


Time: 2.44 secs; Memory: 16MB

docker-compose run --rm -T php composer run phpstan
> phpstan analyse src -c phpstan.neon --level=8 --no-progress -vvv

 [OK] No errors                                                                 

docker-compose up -d gotenberg
gotenberg is up-to-date
docker-compose run --rm -T php composer run phpunit
> phpunit --configuration phpunit.xml.dist
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

......                                                              6 / 6 (100%)

Time: 37.05 seconds, Memory: 14.00 MB

OK (6 tests, 28 assertions)

Generating code coverage report in Clover XML format ... done
docker-compose down
Stopping gotenberg ... done
Removing gotenberg ... done
Removing network gotenberg-php-client_default
```

**Checklist**

- [X] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [X] Have you lint your code locally prior to submission (`make lint`)?
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally (`make tests`)?
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code