### PR TITLE
Client Interface

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,6 @@ name: "Continuous Integration"
 
 on:
   pull_request:
-  pull_request_target:
   push:
     branches:
       - master

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,7 +15,7 @@ use function fclose;
 use function fopen;
 use function fwrite;
 
-final class Client
+final class Client implements GotenbergClientInterface
 {
     /** @var HttpClient */
     private $client;
@@ -30,7 +30,7 @@ final class Client
     }
 
     /**
-     * Sends the given documents to the API and returns the response.
+     * {@inheritdoc}
      *
      * @throws ClientException
      * @throws Exception
@@ -41,7 +41,7 @@ final class Client
     }
 
     /**
-     * Sends the given documents to the API, stores the resulting PDF in the given destination.
+     * {@inheritdoc}
      *
      * @throws ClientException
      * @throws RequestException

--- a/src/GotenbergClientInterface.php
+++ b/src/GotenbergClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\Gotenberg;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface GotenbergClientInterface
+{
+    /**
+     * Sends the given documents to the API and returns the response.
+     */
+    public function post(GotenbergRequestInterface $request): ResponseInterface;
+
+    /**
+     * Sends the given documents to the API, stores the resulting PDF in the given destination.
+     */
+    public function store(GotenbergRequestInterface $request, string $destination): void;
+}


### PR DESCRIPTION
**Summary**

Adds an interface `GotenbergClientInterface`, implemented by the `Client` class.

The purpose is to aid testing in other applications so the client class can be easily mocked, as the current `Client` class is final which makes it tricky to simulate in unit tests. Currently when working with tools that do not allow mocking final classes you need to instantiate the client class and mock the http client and internal interactions with the request/response classes, as well as file writes.

**Test plan (required)**

I've not added any tests as this is a non-functional change - we could test the interface is implemented though if you think it's worth it?

**Checklist**

- [X] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [X] Have you lint your code locally prior to submission (`make lint`)?
- [X] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally (`make tests`)?
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code