### PR TITLE
Loosen the guzzlehttp/psr7 requirements to allow v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php-http/client-implementation": "^1.0",
     "php-http/httplug": ">=1.0",
     "php-http/discovery": "^1.0",
-    "guzzlehttp/psr7": "^1.4.2",
+    "guzzlehttp/psr7": "^1.4.2|^2.0",
     "php-http/message": "^1.0"
   },
   "require-dev" : {

--- a/src/DocumentFactory.php
+++ b/src/DocumentFactory.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace TheCodingMachine\Gotenberg;
 
 use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\StreamInterface;
 use function fopen;
 use function fwrite;
-use function GuzzleHttp\Psr7\stream_for;
 
 final class DocumentFactory
 {
@@ -36,6 +36,6 @@ final class DocumentFactory
             throw FilesystemException::createFromPhpError();
         }
 
-        return new Document($fileName, stream_for($fileStream));
+        return new Document($fileName, new Stream($fileStream));
     }
 }


### PR DESCRIPTION
Fixes #28 

**Summary**

This adds guzzlehttp/psr7": "^2.0" as a requirement in addition to the existing guzzlehttp/psr7": "^1.4.2
