### PR TITLE
Explicitly state that the library is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ⚠️ For **Gotenberg 7.x**, use [gotenberg-/gotenberg-php](https://github.com/gotenberg/gotenberg-php) instead.
 
+_This library is unmaintained and will not receive updates. Consider migrating to *Gotenberg 7.x* and the according new library instead._
+
 # Gotenberg PHP client
 
 A simple PHP client for interacting with a Gotenberg API.


### PR DESCRIPTION
As stated here https://github.com/thecodingmachine/gotenberg-php-client/issues/28#issuecomment-1247800797 I think it's useful to be explicit about it :slightly_smiling_face: